### PR TITLE
chore: 添加项目基础配置文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+**/.env
+.editorconfig
+**/config.yml
+
+chroma
+chroma-data
+mysql-data
+meili-data
+redis-data
+/.husky/_/


### PR DESCRIPTION
chore: 添加项目基础配置文件

添加 .gitignore 文件，包含以下内容：
- 日志文件过滤规则
- node_modules、dist 等构建产物目录
- 编辑器相关文件和目录
- 数据库和缓存数据目录
- husky 配置目录